### PR TITLE
Make the menu appear when introHeight is large

### DIFF
--- a/assets/sass/_base.sass
+++ b/assets/sass/_base.sass
@@ -168,6 +168,16 @@ hr
 .has-content-centered
     justify-content: center
 
+.hero
+  &.is-bottom-menu
+    min-height: 80vh
+    .hero-body
+      align-items: center
+      display: flex
+      & > .container
+        flex-grow: 1
+        flex-shrink: 1
+
 .markdown
     p
         margin-bottom: 1em

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,11 @@
     <body>
         <section id="top" class="section">
             {{ with .Site.GetPage "/home" }}
-            <div class="hero is-{{ .Site.Params.home.introHeight | default "large" }}">
+	    {{ $introClass := .Site.Params.home.introHeight | default "bottom-menu" }}
+	    {{ if eq $introClass "large" }}
+	        {{ $introClass = "bottom-menu" }}
+	    {{ end }}
+            <div class="hero is-{{ $introClass }}">
                 <!-- Super sweet Hero body title -->
                 <div class="hero-body">
                     <div class="container has-text-centered">


### PR DESCRIPTION
To that effect, introduce a new hero is-bottom-menu class which uses
viewport height at 80% to give room for the menu (can't be perfect since
we of course can't mix vh and rem units). Also make sure we use that
class instead of is-large when introHeight is set to large.

That should match the behavior discussed previously.