### PR TITLE
Show date in lists only if set by page

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,9 +5,15 @@
     <div class="container">
         <ul>
             {{ range .Pages.ByPublishDate.Reverse }}
+            {{ if .Date }}
             <li>
                 <a href="{{ .Permalink }}">{{ .Date.Format (.Site.Params.dateFormat | default "Jan 02, 2006") }} | {{ .Title }}</a>
             </li>
+            {{ else }}
+            <li>
+                <a href="{{ .Permalink }}">{{ .Title }}</a>
+            </li>
+            {{ end }}
             {{ end }}
         </ul>
     </div>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -6,9 +6,15 @@
     <div class="container">
         <ul>
             {{ range .Pages.ByPublishDate.Reverse }}
+            {{ if .Date }}
             <li>
                 <a href="{{ .Permalink }}">{{ .Date.Format (.Site.Params.dateFormat | default "Jan 02, 2006") }} | {{ .Title }}</a>
             </li>
+            {{ else }}
+            <li>
+                <a href="{{ .Permalink }}">{{ .Title }}</a>
+            </li>
+            {{ end }}
             {{ end }}
         </ul>
     </div>


### PR DESCRIPTION
If date is not set, a broken (formatted) date like "Jan 1., 0001" is shown. This is fixed by checking via if condition if date is set.